### PR TITLE
Add run_jupyter.sh

### DIFF
--- a/run_jupyter.sh
+++ b/run_jupyter.sh
@@ -1,0 +1,1 @@
+docker run -e GRANT_SUDO=yes -d -p 8888:8888 --rm -v /jupyter:/home/jovyan/work --user 1000:994 chemowakate/tutorial-7th start-notebook.sh --NotebookApp.password='sha1:4d295dded8f2:6d44d26960204e16891c7aba6726edbd52fe4b29'


### PR DESCRIPTION
Jupyter Notebook をサーバーからDockerで立ち上げクライアント側から実行するようにするための
スクリプトを作成する。

権限をdrwxrwxr-x root dockerにした
/jupyter
フォルダをマウントしている。